### PR TITLE
changed cursor type to grab when hover and to grabbing when active in

### DIFF
--- a/src/components/MapContainer/Map/Map.css
+++ b/src/components/MapContainer/Map/Map.css
@@ -6,6 +6,18 @@
   width: '100%';
 }
 
+.ol-map:hover {
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+}
+
+.ol-map:active {
+  cursor: -webkit-grabbing;
+  cursor: -webkit-grabbing;
+  cursor: grabbing;
+}
+
 .ol-control {
   position: absolute;
   background-color: rgba(15, 1, 210, 0.4);


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/67229156/111895925-eedb8700-8a3b-11eb-8263-1690f45acd4c.gif)

After
![after](https://user-images.githubusercontent.com/67229156/111895932-f6029500-8a3b-11eb-8254-7e4f3b0a23be.gif)

### Changes

- In orcamap-react\src\components\MapContainer\Map\Map.css set cursor property of .ol-map to grab hen hover

- In orcamap-react\src\components\MapContainer\Map\Map.css set cursor property of .ol-map to grabbing when active