### PR TITLE
Map responsive using css

### DIFF
--- a/src/components/MapContainer/Map/Map.css
+++ b/src/components/MapContainer/Map/Map.css
@@ -1,9 +1,7 @@
 .ol-map {
-  min-width: 600px;
-  min-height: 500px;
-  margin: 50px;
-  height: 500px;
-  width: '100%';
+  height: 80vh;
+  width: 100vw;
+  margin: 1rem 0;
 }
 
 .ol-map:hover {
@@ -20,12 +18,11 @@
 
 .ol-control {
   position: absolute;
-  background-color: rgba(15, 1, 210, 0.4);
   border-radius: 4px;
-  padding: 2px;
+  margin: 1rem;
 }
 
 .ol-full-screen {
-  top: 0.5em;
-  right: 0.5em;
+  top: 0.5rem;
+  right: 0.5rem;
 }

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -26,7 +26,7 @@ const MapContainer: React.FC = () => {
 
   return (
     <>
-      <div id="cetacean_checkbox" style={{ margin: '0 40vw' }}>
+      <div id="cetacean_checkbox">
         <img
           src={orca}
           width="25px"

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,9 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.App {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}


### PR DESCRIPTION
## This fixes #31 

## Changes
- fixed issues regarding the unresponsiveness of the map in smaller devices (was due to uses of `min-height` and `min-width`)
- removed inline styling from all files: as inline styling is harder to manage and fix if we run into an issue

##  Screenshots

#### Mobile view
![Screenshot from 2021-03-21 11-24-06](https://user-images.githubusercontent.com/60931421/111895364-09136600-8a38-11eb-9329-d0b69b00c633.png)

#### Desktop view
![Screenshot from 2021-03-21 11-24-22](https://user-images.githubusercontent.com/60931421/111895367-10d30a80-8a38-11eb-98b5-956cace403a7.png)
